### PR TITLE
石を動かす

### DIFF
--- a/game.py
+++ b/game.py
@@ -10,24 +10,40 @@ class App:
         pyxel.mouse(True)
         pyxel.load("my_resource.pyxres")
         self.player_x = SCREEN_WIDTH // 2
+        self.player_y = SCREEN_HEIGHT * 4 // 4
+        self.stone_x = SCREEN_WIDTH // 2
+        self.stone_y = 0
+        self.is_collision = False
         pyxel.run(self.update, self.draw)
 
     def update(self):
        if pyxel.btnp(pyxel.KEY_ESCAPE):
            pyxel.quit()
 
+        # プレーヤーの移動
        if pyxel.btn(pyxel.KEY_RIGHT) and self.player_x < SCREEN_WIDTH - 12:
            self.player_x += 1
        elif pyxel.btn(pyxel.KEY_LEFT) and self.player_x > -4:
            self.player_x -= 1
 
+        # 石の落下
+       if self.stone_y < SCREEN_HEIGHT:
+           self.stone_y += 1
+
+        # 衝突
+       if (self.player_x <= self.stone_x <= self.player_x + 8 and
+           self.player_y <= self.stone_y <= self.player_y + 8):
+           self.is_collision = True
            
     def draw(self):
         pyxel.cls(pyxel.COLOR_DARK_BLUE)
         # 石
-        pyxel.blt(SCREEN_WIDTH // 2, 0, 0 ,8, 0, 8, 8, pyxel.COLOR_BLACK)
+        pyxel.blt(self.stone_x, self.stone_y, 0 ,8, 0, 8, 8, pyxel.COLOR_BLACK)
         # プレーヤー
-        pyxel.blt(self.player_x, SCREEN_HEIGHT * 4 // 5, 0, 16, 0, 16, 16, 
+        pyxel.blt(self.player_x, self.player_y * 4 // 5, 0, 16, 0, 16, 16, 
                   pyxel.COLOR_BLACK)
 
+        if self.is_collision:
+            pyxel.text(SCREEN_WIDTH // 2 -20, SCREEN_HEIGHT // 2,
+                       "Game Over", pyxel.COLOR_YELLOW)
 App()


### PR DESCRIPTION
# What
プレーヤーのx,y座標を変数にして可読性を向上
石の初期値設定
update関数内にself.stone_y += 1を代入することでフレームごとに石が落下するようになった。 特定の位置に石が当たるとゲームオーバーと表示されるように設定した。

# Why
石の落下、接触してゲームオーバーと表示させることでインベーダーゲームの要素を学ぶことが目的であるため